### PR TITLE
move custom template overrides into sub-folder

### DIFF
--- a/drs-tk.php
+++ b/drs-tk.php
@@ -30,8 +30,8 @@ $TEMPLATE = array(
 );
 
 $TEMPLATE_THEME = array(
-    'browse_template' => 'drstk-browse.php',
-    'item_template' => 'drstk-item.php',
+    'browse_template' => 'overrides/drstk-browse.php',
+    'item_template' => 'overrides/drstk-item.php',
 );
 
  register_activation_hook( __FILE__, 'drstk_install' );


### PR DESCRIPTION
Because we are now using the `overrides` folder in the sub-theme, I think it makes most sense to look for thse template files in that folder (rather than the root sub-theme folder); this way everything can remain comitted together in the same submodule.