### PR TITLE
display the "listbar" to access playlist

### DIFF
--- a/inc/video_shortcode.php
+++ b/inc/video_shortcode.php
@@ -84,6 +84,11 @@ function drstk_collection_playlist($atts){
           fallback: "false",
           androidhls: "true",
           primary: primary,
+          listbar: {
+            position: "right",
+            size: 250,
+            layout: "basic"
+          },
           playlist: [ '. $playlists . ']
         });
         var errorMessage = function(e) {


### PR DESCRIPTION
the list bar wasn't being displayed with the video playlist shortcake ... added it (maybe new setting since you upgraded jwplayer)