### PR TITLE
Allow dditional shortcode options for jwplayer

### DIFF
--- a/inc/video_shortcode.php
+++ b/inc/video_shortcode.php
@@ -19,6 +19,11 @@ function drstk_collection_playlist($atts){
     } else {
       $width = '100%';
     }
+    if (isset($atts['aspectratio'])){
+      $aspectratio = $atts['aspectratio'];
+    } else {
+      $aspectratio = '16:9';
+    }
     foreach($collection as $video){
         $url = "https://repository.library.northeastern.edu/api/v1/files/" . $video;
         $data = get_response($url);
@@ -83,6 +88,7 @@ function drstk_collection_playlist($atts){
           provider: "'.$provider.'",
           fallback: "false",
           androidhls: "true",
+          aspectratio:"'.$aspectratio.'",
           primary: primary,';
     if(count($collection) > 1){
         $cache_output .= 'listbar: {

--- a/inc/video_shortcode.php
+++ b/inc/video_shortcode.php
@@ -24,6 +24,11 @@ function drstk_collection_playlist($atts){
     } else {
       $aspectratio = '16:9';
     }
+    if (isset($atts['skin'])){
+      $skin = $atts['skin'];
+    } else {
+      $skin = 'six';
+    }
     foreach($collection as $video){
         $url = "https://repository.library.northeastern.edu/api/v1/files/" . $video;
         $data = get_response($url);
@@ -89,6 +94,7 @@ function drstk_collection_playlist($atts){
           fallback: "false",
           androidhls: "true",
           aspectratio:"'.$aspectratio.'",
+          skin:"'.$skin.'",
           primary: primary,';
     if(count($collection) > 1){
         $cache_output .= 'listbar: {

--- a/inc/video_shortcode.php
+++ b/inc/video_shortcode.php
@@ -29,6 +29,11 @@ function drstk_collection_playlist($atts){
     } else {
       $skin = 'six';
     }
+    if (isset($atts['listbarwidth']) && $atts['listbarwidth'] != 0){
+      $listbarwidth = $atts['listbarwidth'];
+    } else {
+      $listbarwidth = '250';
+    }
     foreach($collection as $video){
         $url = "https://repository.library.northeastern.edu/api/v1/files/" . $video;
         $data = get_response($url);
@@ -99,7 +104,7 @@ function drstk_collection_playlist($atts){
     if(count($collection) > 1){
         $cache_output .= 'listbar: {
           position: "right",
-          size: 250,
+          size: '.$listbarwidth.',
           layout: "basic"
         },';
     }


### PR DESCRIPTION
Just added a few more shortcode options that I found myself needing; without supplying any of these the player should render mostly as it has been ... with the exception of the `aspectratio` one which will now default to "16:9" ... which I think is sensible.

Here they are:

* aspectratio (default="16:9")
* skin (default="six")
* listbarwidth (default=250)